### PR TITLE
Update query to only look up journal pages, fixes #10

### DIFF
--- a/src/features/libs/index.ts
+++ b/src/features/libs/index.ts
@@ -31,6 +31,8 @@ export const findEvents = async (): Promise<EventObject[] | undefined> => {
   const query = await logseq.DB.datascriptQuery(`[
         :find (pull ?b [*])
         :where
+               [?b :block/page ?page]
+               [?page :block/journal? true]
                [?b :block/parent ?parent]
                [?b :block/properties ?p]
                [(get ?p :start-time) ?ty]


### PR DESCRIPTION
Hi! This PR tries to address #10 by updating the query to only look for journal pages.

I have tested it locally, and it seems to be working for me. This is my first experience in Logseq plugin development, I may be missing or misunderstading something. I would appreciate it if you checked this out and gave me any feedback you can.

Thank you.